### PR TITLE
Add coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,4 +1,0 @@
-module.exports = {
-	port: 8545,
-	norpc: true
-}

--- a/contracts/BasicToken.sol
+++ b/contracts/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import './SafeMath.sol';
 import './ERC20.sol';

--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 /// @title ERC Token Standard #20 Interface (https://github.com/ethereum/EIPs/issues/20)
 contract ERC20 {

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 /// @title Math operations with safety checks
 library SafeMath {

--- a/contracts/helpers/BasicTokenMock.sol
+++ b/contracts/helpers/BasicTokenMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 import '../BasicToken.sol';
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "solidity-coverage": "^0.4.9"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "coverage": "./node_modules/.bin/solidity-coverage"
   },
   "author": "",
   "license": "ISC"

--- a/truffle.js
+++ b/truffle.js
@@ -8,7 +8,9 @@ module.exports = {
     coverage: {
       host: "localhost",
       network_id: "*",
-      port: 8545,         // <-- If you change this, also set the port option in .solcover.js.
+      port: 8555,         // <-- If you change this, also set the port option in .solcover.js.
+      gas: 0xfffffffffff, // <-- Use this high gas value
+      gasPrice: 0x01      // <-- Use this low gas price
     },
   }
 };


### PR DESCRIPTION
Modified the config a bit. You should be able to generate coverage with: `npm run coverage`.  I had to float the pragma's on a caret to get the contracts to compile on my global version of Truffle which uses solc `0.4.19`, but this shouldn't be necessary in your local environment.

![screen shot 2018-02-12 at 8 06 19 am](https://user-images.githubusercontent.com/7332026/36106263-b0a4ae78-0fcb-11e8-8504-f58aef4a0db4.png)

Just let me know if you run into further problems or if the solution here doesn't work for the larger project. 